### PR TITLE
Allow EKS cluster creation when multiple AWS profile are defined

### DIFF
--- a/cluster/provider.tf
+++ b/cluster/provider.tf
@@ -3,6 +3,7 @@ provider "aws" {
   access_key = var.AWS_ACCESS_KEY_ID
   secret_key = var.AWS_SECRET_ACCESS_KEY
   token      = var.AWS_SESSION_TOKEN
+  profile    = var.AWS_PROFILE
 }
 
 provider "kubernetes" {
@@ -11,7 +12,7 @@ provider "kubernetes" {
 
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
-    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name, "--region", var.AWS_REGION]
+    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name, "--region", var.AWS_REGION, "--profile", var.AWS_PROFILE]
     command     = "aws"
   }
 }
@@ -24,7 +25,7 @@ provider "kubectl" {
 
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
-    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name, "--region", var.AWS_REGION]
+    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name, "--region", var.AWS_REGION, "--profile", var.AWS_PROFILE]
     command     = "aws"
   }
 }

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -7,12 +7,14 @@ variable "AWS_REGION" {
 variable "AWS_ACCESS_KEY_ID" {
   type        = string
   description = "AWS access key associated with an IAM account"
+  default     = ""
   sensitive   = true
 }
 
 variable "AWS_SECRET_ACCESS_KEY" {
   type        = string
   description = "AWS secret key associated with the access key"
+  default     = ""
   sensitive   = true
 }
 

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -23,6 +23,12 @@ variable "AWS_SESSION_TOKEN" {
   sensitive   = true
 }
 
+variable "AWS_PROFILE" {
+  type        = string
+  description = "AWS Profile that resources are created in"
+  default     = "default"
+}
+
 variable "eks_cluster_name" {
   type        = string
   description = "EKS cluster name"

--- a/config/provider.tf
+++ b/config/provider.tf
@@ -3,6 +3,7 @@ provider "aws" {
   access_key = var.AWS_ACCESS_KEY_ID
   secret_key = var.AWS_SECRET_ACCESS_KEY
   token      = var.AWS_SESSION_TOKEN
+  profile    = var.AWS_PROFILE
 }
 
 provider "kubernetes" {

--- a/config/variables.tf
+++ b/config/variables.tf
@@ -23,6 +23,12 @@ variable "AWS_SESSION_TOKEN" {
   sensitive   = true
 }
 
+variable "AWS_PROFILE" {
+  type        = string
+  description = "AWS Profile that resources are created in"
+  default     = "default"
+}
+
 variable "eks_cluster_name" {
   type        = string
   description = "EKS cluster name"


### PR DESCRIPTION
Aiming to fix #5. 
Also added the cluster prefix to the node groups so they'd be easier to distinguish EC2 servers list. **Note:**  This will delete and recreate node groups, might cause slight disruptions. 