### PR TITLE
Add the option to deploy K8s metrics server

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Optional resource creations are disabled by default. To enable the creation of a
 Created resources (if all enabled):
 * EIP allocated for the load balancer created by Ingress-NGINX
 * Karpenter provisioner, the node template and the SQS interruption queue
+* Metrics Server along with the Kubernetes Dashboard and the read-only user
 * MSK cluster featuring Kafka brokers and zookeepers
 * RDS instance running managementportal, appserver and rest_sources_auth databases
 * Route53 zone and records accompanied by IRSAs for external DNS and Cert Manager

--- a/config/metrics.tf
+++ b/config/metrics.tf
@@ -15,6 +15,152 @@ resource "helm_release" "metrics_server" {
   wait = true
 }
 
-output "metrics_server_metadata" {
-  value = var.enable_metrics ? helm_release.metrics_server[0].metadata : null
+resource "kubernetes_namespace" "kubernetes_dashboard" {
+  count = var.enable_metrics ? 1 : 0
+
+  metadata {
+    name = "kubernetes-dashboard"
+  }
+}
+
+resource "helm_release" "kubernetes_dashboard" {
+  count = var.enable_metrics ? 1 : 0
+
+  name       = "kubernetes-dashboard"
+  repository = "https://kubernetes.github.io/dashboard/"
+  chart      = "kubernetes-dashboard"
+  namespace  = kubernetes_namespace.kubernetes_dashboard[0].metadata[0].name
+  version    = var.kubernetes_dashboard_version
+
+  depends_on = [kubernetes_namespace.kubernetes_dashboard]
+
+}
+
+resource "kubernetes_service_account_v1" "dashboard_user" {
+  count = var.enable_metrics ? 1 : 0
+
+  metadata {
+    name      = "dashboard-user"
+    namespace = helm_release.kubernetes_dashboard[0].name
+  }
+
+  depends_on = [
+    helm_release.kubernetes_dashboard
+  ]
+}
+
+resource "kubernetes_secret_v1" "dashboard_user" {
+  count = var.enable_metrics ? 1 : 0
+
+  metadata {
+    name      = "dashboard-user-token"
+    namespace = kubernetes_namespace.kubernetes_dashboard[0].metadata[0].name
+    annotations = {
+      "kubernetes.io/service-account.name" = kubernetes_service_account_v1.dashboard_user[0].metadata[0].name
+    }
+  }
+  type                           = "kubernetes.io/service-account-token"
+  wait_for_service_account_token = true
+
+  depends_on = [
+    helm_release.kubernetes_dashboard
+  ]
+}
+
+resource "kubernetes_cluster_role_v1" "read_only" {
+  count = var.enable_metrics ? 1 : 0
+
+  metadata {
+    name = "read-only-cluster-role"
+  }
+
+  rule {
+    api_groups = [""]
+    resources = [
+      "bindings", "configmaps", "deployments", "endpoints", "events", "ingressclasses",
+      "limitranges", "namespaces", "namespaces/status", "nodes", "persistentvolumeclaims", "persistentvolumes",
+      "pods", "pods/log", "pods/status", "replicasets", "replicationcontrollers", "replicationcontrollers",
+      "replicationcontrollers/scale", "replicationcontrollers/status", "resourcequotas", "resourcequotas/status",
+      "secrets", "serviceaccounts", "services", "services",
+    ]
+    verbs = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["apps"]
+    resources  = ["daemonsets", "deployments", "deployments/scale", "replicasets", "replicasets/scale", "statefulsets"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["autoscaling"]
+    resources  = ["horizontalpodautoscalers"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["batch"]
+    resources  = ["cronjobs", "jobs"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["extensions"]
+    resources = [
+      "daemonsets", "deployments", "deployments/scale", "ingresses", "networkpolicies",
+      "replicasets", "replicasets/scale", "replicationcontrollers/scale",
+    ]
+    verbs = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["networking.k8s.io"]
+    resources  = ["ingresses", "ingressclasses", "networkpolicies"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["policy"]
+    resources  = ["poddisruptionbudgets"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["rbac.authorization.k8s.io"]
+    resources  = ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["storage.k8s.io"]
+    resources  = ["storageclasses", "volumeattachments"]
+    verbs      = ["get", "list", "watch"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding_v1" "dashboard_user" {
+  count = var.enable_metrics ? 1 : 0
+
+  metadata {
+    name = "dashboard-user"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role_v1.read_only[0].metadata[0].name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account_v1.dashboard_user[0].metadata[0].name
+    namespace = kubernetes_namespace.kubernetes_dashboard[0].metadata[0].name
+  }
+  depends_on = [
+    helm_release.kubernetes_dashboard,
+    kubernetes_service_account_v1.dashboard_user
+  ]
+}
+
+output "radar_base_k8s_dashboard_user_token" {
+  value     = var.enable_metrics ? kubernetes_secret_v1.dashboard_user[0].data.token : null
+  sensitive = true
 }

--- a/config/metrics.tf
+++ b/config/metrics.tf
@@ -1,0 +1,20 @@
+resource "helm_release" "metrics_server" {
+  count = var.enable_metrics ? 1 : 0
+
+  name       = "metrics-server"
+  repository = "https://kubernetes-sigs.github.io/metrics-server/"
+  chart      = "metrics-server"
+  namespace  = "kube-system"
+  version    = var.metrics_server_version
+
+  set {
+    name  = "apiService.insecureSkipTLSVerify"
+    value = "true"
+  }
+
+  wait = true
+}
+
+output "metrics_server_metadata" {
+  value = var.enable_metrics ? helm_release.metrics_server[0].metadata : null
+}

--- a/config/s3.tf
+++ b/config/s3.tf
@@ -101,7 +101,8 @@ output "radar_base_s3_velero_bucket_name" {
 }
 
 output "radar_base_s3_access_key" {
-  value = var.enable_s3 ? aws_iam_access_key.s3_access[0].id : null
+  value     = var.enable_s3 ? aws_iam_access_key.s3_access[0].id : null
+  sensitive = true
 }
 
 output "radar_base_s3_secret_key" {

--- a/config/terraform.tfvars
+++ b/config/terraform.tfvars
@@ -1,6 +1,6 @@
 AWS_REGION       = "eu-west-2"
 environment      = "dev"
-domain_name      = {} # Pair of top level domain and hosted zone ID for deployed applications
+domain_name      = {} # Pair of top level domain and hosted zone ID for deployed applications, e.g., { "radar-base.org" : "ZABCDEFGHIJKLMNOPQRST" }
 with_dmz_pods    = false
 enable_metrics   = false
 enable_karpenter = false

--- a/config/terraform.tfvars
+++ b/config/terraform.tfvars
@@ -2,6 +2,7 @@ AWS_REGION       = "eu-west-2"
 environment      = "dev"
 domain_name      = {} # Pair of top level domain and hosted zone ID for deployed applications
 with_dmz_pods    = false
+enable_metrics   = false
 enable_karpenter = false
 enable_msk       = false
 enable_rds       = false

--- a/config/variables.tf
+++ b/config/variables.tf
@@ -75,6 +75,11 @@ variable "metrics_server_version" {
   default = "3.12.1"
 }
 
+variable "kubernetes_dashboard_version" {
+  type    = string
+  default = "7.3.2"
+}
+
 variable "kafka_version" {
   type    = string
   default = "3.2.0"

--- a/config/variables.tf
+++ b/config/variables.tf
@@ -70,6 +70,11 @@ variable "instance_capacity_type" {
   }
 }
 
+variable "metrics_server_version" {
+  type    = string
+  default = "3.12.1"
+}
+
 variable "kafka_version" {
   type    = string
   default = "3.2.0"
@@ -98,6 +103,11 @@ variable "with_dmz_pods" {
   type        = bool
   description = "Whether or not to utilise the DMZ node group if it exists"
   default     = false
+}
+
+variable "enable_metrics" {
+  type        = bool
+  description = "Do you need Metrics Server? [true, false]"
 }
 
 variable "enable_karpenter" {


### PR DESCRIPTION
This PR adds the option to deploy the Metrics Server and gives users read-only access to the Kubernetes Dashboard.