### PR TITLE
Remove terraform version lock

### DIFF
--- a/cluster/versions.tf
+++ b/cluster/versions.tf
@@ -13,5 +13,5 @@ terraform {
       version = "~> 1.14.0"
     }
   }
-  required_version = ">= 1.7.0, < 1.8.0"
+  required_version = ">= 1.7.0"
 }

--- a/config/versions.tf
+++ b/config/versions.tf
@@ -17,5 +17,5 @@ terraform {
       version = "~> 1.14.0"
     }
   }
-  required_version = ">= 1.7.0, < 1.8.0"
+  required_version = ">= 1.7.0"
 }


### PR DESCRIPTION
From the last version update 3 months ago Terraform is already on version 1.9.5. I think it is better to remove the upper limit on Terraform version or set it only for major version to remove the need to update this version often.