### PR TITLE
Support latest EKS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Created resources (if all enabled):
 
 Make sure to install [terraform-docs](https://github.com/terraform-docs/terraform-docs) and run `make prepare` before making a commit to make sure the documentation is up to date and the code is valid.
 
+In order to support new version of EKS you need to make sure the addons that we use are compatible with the new target version. You can get a list of addons and their EKS compatiblity with running `aws eks describe-addons-versions` and then searching for the addons that are defined in `cluster/data.tf`.
+
 ## Known limitations
 
 - Since EBS has been chosen as the default storage, node groups will be created in a single AZ due to the mounting restriction.

--- a/cluster/README.md
+++ b/cluster/README.md
@@ -51,9 +51,10 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_AWS_ACCESS_KEY_ID"></a> [AWS\_ACCESS\_KEY\_ID](#input\_AWS\_ACCESS\_KEY\_ID) | AWS access key associated with an IAM account | `string` | n/a | yes |
+| <a name="input_AWS_ACCESS_KEY_ID"></a> [AWS\_ACCESS\_KEY\_ID](#input\_AWS\_ACCESS\_KEY\_ID) | AWS access key associated with an IAM account | `string` | `""` | no |
+| <a name="input_AWS_PROFILE"></a> [AWS\_PROFILE](#input\_AWS\_PROFILE) | AWS Profile that resources are created in | `string` | `"default"` | no |
 | <a name="input_AWS_REGION"></a> [AWS\_REGION](#input\_AWS\_REGION) | Target AWS region | `string` | `"eu-west-2"` | no |
-| <a name="input_AWS_SECRET_ACCESS_KEY"></a> [AWS\_SECRET\_ACCESS\_KEY](#input\_AWS\_SECRET\_ACCESS\_KEY) | AWS secret key associated with the access key | `string` | n/a | yes |
+| <a name="input_AWS_SECRET_ACCESS_KEY"></a> [AWS\_SECRET\_ACCESS\_KEY](#input\_AWS\_SECRET\_ACCESS\_KEY) | AWS secret key associated with the access key | `string` | `""` | no |
 | <a name="input_AWS_SESSION_TOKEN"></a> [AWS\_SESSION\_TOKEN](#input\_AWS\_SESSION\_TOKEN) | Session token for temporary security credentials from AWS STS | `string` | `""` | no |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Common tags associated to resources created | `map(string)` | <pre>{<br>  "Environment": "dev",<br>  "Project": "radar-base"<br>}</pre> | no |
 | <a name="input_create_dmz_node_group"></a> [create\_dmz\_node\_group](#input\_create\_dmz\_node\_group) | Whether or not to create a DMZ node group with taints | `bool` | `false` | no |
@@ -61,7 +62,7 @@
 | <a name="input_dmz_node_size"></a> [dmz\_node\_size](#input\_dmz\_node\_size) | Node size of the DMZ node group | `map(number)` | <pre>{<br>  "desired": 1,<br>  "max": 2,<br>  "min": 0<br>}</pre> | no |
 | <a name="input_eks_admins_group_users"></a> [eks\_admins\_group\_users](#input\_eks\_admins\_group\_users) | EKS admin IAM user group | `list(string)` | `[]` | no |
 | <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | EKS cluster name | `string` | n/a | yes |
-| <a name="input_eks_kubernetes_version"></a> [eks\_kubernetes\_version](#input\_eks\_kubernetes\_version) | Amazon EKS Kubernetes version | `string` | `"1.28"` | no |
+| <a name="input_eks_kubernetes_version"></a> [eks\_kubernetes\_version](#input\_eks\_kubernetes\_version) | Amazon EKS Kubernetes version | `string` | `"1.31"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name | `string` | `"dev"` | no |
 | <a name="input_instance_capacity_type"></a> [instance\_capacity\_type](#input\_instance\_capacity\_type) | Capacity type used by EKS managed node groups | `string` | `"SPOT"` | no |
 | <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | List of instance types used by EKS managed node groups | `list(any)` | <pre>[<br>  "m5.large",<br>  "m5d.large",<br>  "m5a.large",<br>  "m5ad.large",<br>  "m4.large"<br>]</pre> | no |

--- a/cluster/data.tf
+++ b/cluster/data.tf
@@ -1,42 +1,42 @@
 locals {
 
   eks_core_versions = {
+    "1.31" : {
+      "cluster_version" = "1.31"
+      "cluster_addons" = {
+        "coredns"        = "v1.11.3-eksbuild.2"
+        "kube_proxy"     = "v1.31.2-eksbuild.3"
+        "vpc_cni"        = "v1.19.0-eksbuild.1"
+        "ebs_csi_driver" = "v1.37.0-eksbuild.1"
+      }
+    },
+    "1.30" : {
+      "cluster_version" = "1.30"
+      "cluster_addons" = {
+        "coredns"        = "v1.11.3-eksbuild.2"
+        "kube_proxy"     = "v1.30.6-eksbuild.3"
+        "vpc_cni"        = "v1.19.0-eksbuild.1"
+        "ebs_csi_driver" = "v1.37.0-eksbuild.1"
+      }
+    },
     "1.29" : {
       "cluster_version" = "1.29"
       "cluster_addons" = {
-        "coredns"        = "v1.11.1-eksbuild.4"
-        "kube_proxy"     = "v1.29.0-eksbuild.2"
-        "vpc_cni"        = "v1.16.4-eksbuild.2"
-        "ebs_csi_driver" = "v1.26.1-eksbuild.1"
+        "coredns"        = "v1.11.3-eksbuild.2"
+        "kube_proxy"     = "v1.29.10-eksbuild.3"
+        "vpc_cni"        = "v1.19.0-eksbuild.1"
+        "ebs_csi_driver" = "v1.37.0-eksbuild.1"
       }
     },
     "1.28" : {
       "cluster_version" = "1.28"
       "cluster_addons" = {
-        "coredns"        = "v1.10.1-eksbuild.10"
-        "kube_proxy"     = "v1.28.1-eksbuild.1"
-        "vpc_cni"        = "v1.16.4-eksbuild.2"
-        "ebs_csi_driver" = "v1.26.1-eksbuild.1"
+        "coredns"        = "v1.10.1-eksbuild.15"
+        "kube_proxy"     = "v1.28.15-eksbuild.4"
+        "vpc_cni"        = "v1.19.0-eksbuild.1"
+        "ebs_csi_driver" = "v1.37.0-eksbuild.1"
       }
     },
-    "1.27" : {
-      "cluster_version" = "1.27"
-      "cluster_addons" = {
-        "coredns"        = "v1.10.1-eksbuild.7"
-        "kube_proxy"     = "v1.27.10-eksbuild.2"
-        "vpc_cni"        = "v1.15.3-eksbuild.1"
-        "ebs_csi_driver" = "v1.25.0-eksbuild.1"
-      }
-    },
-    "1.26" : {
-      "cluster_version" = "1.26"
-      "cluster_addons" = {
-        "coredns"        = "v1.9.3-eksbuild.2"
-        "kube_proxy"     = "v1.26.2-eksbuild.1"
-        "vpc_cni"        = "v1.12.2-eksbuild.1"
-        "ebs_csi_driver" = "v1.17.0-eksbuild.1"
-      }
-    }
   }
 
   storage_classes = {

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -59,11 +59,11 @@ variable "common_tags" {
 variable "eks_kubernetes_version" {
   type        = string
   description = "Amazon EKS Kubernetes version"
-  default     = "1.28"
+  default     = "1.31"
 
   validation {
-    condition     = contains(["1.29", "1.28", "1.27", "1.26"], var.eks_kubernetes_version)
-    error_message = "Invalid EKS Kubernetes version. Supported versions are '1.29', '1.28', '1.27', '1.26'."
+    condition     = contains(["1.31", "1.30", "1.29", "1.28"], var.eks_kubernetes_version)
+    error_message = "Invalid EKS Kubernetes version. Supported versions are '1.31', '1.30', '1.29', '1.28'."
   }
 }
 

--- a/config/README.md
+++ b/config/README.md
@@ -85,6 +85,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_AWS_ACCESS_KEY_ID"></a> [AWS\_ACCESS\_KEY\_ID](#input\_AWS\_ACCESS\_KEY\_ID) | AWS access key associated with an IAM account | `string` | n/a | yes |
+| <a name="input_AWS_PROFILE"></a> [AWS\_PROFILE](#input\_AWS\_PROFILE) | AWS Profile that resources are created in | `string` | `"default"` | no |
 | <a name="input_AWS_REGION"></a> [AWS\_REGION](#input\_AWS\_REGION) | Target AWS region | `string` | `"eu-west-2"` | no |
 | <a name="input_AWS_SECRET_ACCESS_KEY"></a> [AWS\_SECRET\_ACCESS\_KEY](#input\_AWS\_SECRET\_ACCESS\_KEY) | AWS secret key associated with the access key | `string` | n/a | yes |
 | <a name="input_AWS_SESSION_TOKEN"></a> [AWS\_SESSION\_TOKEN](#input\_AWS\_SESSION\_TOKEN) | Session token for temporary security credentials from AWS STS | `string` | `""` | no |


### PR DESCRIPTION
This PR adds support for latest version of EKS and its addons. I did a test install for v1.31 and installation was successful. I assume v1.30 will work as wel.
