### PR TITLE
Create EKS admins group

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,22 @@ Created resources:
 - KMS keys and CloudWatch log groups
 - Essential IAM policies, roles, users and user groups for accessing aforementioned resources
 
+## Crete an AWS profile with EKS admin role
+
+Before accessing the cluster you need to create a new profile in your AWS configuration that uses the role that has been created.
+Copy this this to your AWS configuration file typically located at `~/.aws/config`
+
+```
+[profile eks-admin]
+role_arn = # Put result of the `terraform output assume_eks_admins_role` in here.
+source_profile = # Source profile in AWS config that is a user defined in `eks_admins_group_users` input value.
+```
+
 ## Connect to and verify the cluster
 
 ```
 # Make sure to use --region if the cluster is deployed in non-default region and --profile if the cluster is deployed in a non-default AWS account
-aws eks update-kubeconfig --name [eks_cluster_name]
+aws --profile eks-admin eks update-kubeconfig --name [eks_cluster_name]
 kubectl get nodes
 kubectl get pods -A
 ```

--- a/cluster/README.md
+++ b/cluster/README.md
@@ -32,10 +32,12 @@
 
 | Name | Type |
 |------|------|
+| [aws_iam_group.eks_admins_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group) | resource |
+| [aws_iam_group_membership.eks_admins_group_membership](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_membership) | resource |
+| [aws_iam_group_policy_attachment.eks_admins_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
 | [aws_iam_policy.ecr_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ecr_pull_through_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy_attachment.eks_admins_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
 | [aws_security_group.vpc_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.vpc_endpoint_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.vpc_endpoint_self_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -51,9 +53,10 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_AWS_ACCESS_KEY_ID"></a> [AWS\_ACCESS\_KEY\_ID](#input\_AWS\_ACCESS\_KEY\_ID) | AWS access key associated with an IAM account | `string` | n/a | yes |
+| <a name="input_AWS_ACCESS_KEY_ID"></a> [AWS\_ACCESS\_KEY\_ID](#input\_AWS\_ACCESS\_KEY\_ID) | AWS access key associated with an IAM account | `string` | `""` | no |
+| <a name="input_AWS_PROFILE"></a> [AWS\_PROFILE](#input\_AWS\_PROFILE) | AWS Profile that resources are created in | `string` | `"default"` | no |
 | <a name="input_AWS_REGION"></a> [AWS\_REGION](#input\_AWS\_REGION) | Target AWS region | `string` | `"eu-west-2"` | no |
-| <a name="input_AWS_SECRET_ACCESS_KEY"></a> [AWS\_SECRET\_ACCESS\_KEY](#input\_AWS\_SECRET\_ACCESS\_KEY) | AWS secret key associated with the access key | `string` | n/a | yes |
+| <a name="input_AWS_SECRET_ACCESS_KEY"></a> [AWS\_SECRET\_ACCESS\_KEY](#input\_AWS\_SECRET\_ACCESS\_KEY) | AWS secret key associated with the access key | `string` | `""` | no |
 | <a name="input_AWS_SESSION_TOKEN"></a> [AWS\_SESSION\_TOKEN](#input\_AWS\_SESSION\_TOKEN) | Session token for temporary security credentials from AWS STS | `string` | `""` | no |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Common tags associated to resources created | `map(string)` | <pre>{<br>  "Environment": "dev",<br>  "Project": "radar-base"<br>}</pre> | no |
 | <a name="input_create_dmz_node_group"></a> [create\_dmz\_node\_group](#input\_create\_dmz\_node\_group) | Whether or not to create a DMZ node group with taints | `bool` | `false` | no |
@@ -71,6 +74,7 @@
 
 | Name | Description |
 |------|-------------|
+| <a name="output_assume_eks_admins_role"></a> [assume\_eks\_admins\_role](#output\_assume\_eks\_admins\_role) | n/a |
 | <a name="output_radar_base_ebs_storage_class_gp2"></a> [radar\_base\_ebs\_storage\_class\_gp2](#output\_radar\_base\_ebs\_storage\_class\_gp2) | n/a |
 | <a name="output_radar_base_ebs_storage_class_gp3"></a> [radar\_base\_ebs\_storage\_class\_gp3](#output\_radar\_base\_ebs\_storage\_class\_gp3) | n/a |
 | <a name="output_radar_base_ebs_storage_class_io1"></a> [radar\_base\_ebs\_storage\_class\_io1](#output\_radar\_base\_ebs\_storage\_class\_io1) | n/a |

--- a/cluster/iam.tf
+++ b/cluster/iam.tf
@@ -82,10 +82,21 @@ module "allow_assume_eks_admins_iam_policy" {
   tags = merge(tomap({ "Name" : "${var.eks_cluster_name}-allow-assume-eks-admin-role" }), var.common_tags)
 }
 
-resource "aws_iam_policy_attachment" "eks_admins_policy_attachment" {
-  name       = "${var.eks_cluster_name}-eks-admins-policy-attachment"
+resource "aws_iam_group" "eks_admins_group" {
+  name = "${var.eks_cluster_name}-admins"
+  path = "/${var.eks_cluster_name}/"
+}
+
+resource "aws_iam_group_policy_attachment" "eks_admins_policy_attachment" {
+  group      = "${var.eks_cluster_name}-admins"
   policy_arn = module.allow_assume_eks_admins_iam_policy.arn
-  users      = var.eks_admins_group_users
+}
+
+resource "aws_iam_group_membership" "eks_admins_group_membership" {
+  name = "${var.eks_cluster_name}-admin-users"
+
+  users = var.eks_admins_group_users
+  group = "${var.eks_cluster_name}-admins"
 }
 
 module "iam_user" {

--- a/cluster/outputs.tf
+++ b/cluster/outputs.tf
@@ -37,3 +37,7 @@ output "radar_base_ebs_storage_class_io1" {
 output "radar_base_ebs_storage_class_io2" {
   value = local.storage_classes.io2
 }
+
+output "assume_eks_admins_role" {
+  value = module.allow_assume_eks_admins_iam_policy.arn
+}

--- a/config/README.md
+++ b/config/README.md
@@ -85,6 +85,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_AWS_ACCESS_KEY_ID"></a> [AWS\_ACCESS\_KEY\_ID](#input\_AWS\_ACCESS\_KEY\_ID) | AWS access key associated with an IAM account | `string` | n/a | yes |
+| <a name="input_AWS_PROFILE"></a> [AWS\_PROFILE](#input\_AWS\_PROFILE) | AWS Profile that resources are created in | `string` | `"default"` | no |
 | <a name="input_AWS_REGION"></a> [AWS\_REGION](#input\_AWS\_REGION) | Target AWS region | `string` | `"eu-west-2"` | no |
 | <a name="input_AWS_SECRET_ACCESS_KEY"></a> [AWS\_SECRET\_ACCESS\_KEY](#input\_AWS\_SECRET\_ACCESS\_KEY) | AWS secret key associated with the access key | `string` | n/a | yes |
 | <a name="input_AWS_SESSION_TOKEN"></a> [AWS\_SESSION\_TOKEN](#input\_AWS\_SESSION\_TOKEN) | Session token for temporary security credentials from AWS STS | `string` | `""` | no |


### PR DESCRIPTION
Right now when creating an EKS cluster the access is given to the users individually, I think it's a better practice to create a group and add users to that group instead.
I updated the documentation, I hope it's not too vague. 
